### PR TITLE
Disable concurrent builds when started on a schedule

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ if (infra.isTrusted()) {
 if (!env.CHANGE_ID) {
     if (env.BRANCH_NAME == null) {
         projectProperties.add(pipelineTriggers([cron('H/30 * * * *')]))
+        projectProperties.add(disableConcurrentBuilds())
     }
 }
 


### PR DESCRIPTION
If builds started on a schedule of 30 minutes are ever running in parallel, something is wrong and we should not start further builds.

Corresponds to https://github.com/jenkins-infra/jenkins.io/pull/2219