### PR TITLE
chore(Makefile): replace npm install with npm ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ $(BUILD_DIR)/ruby: Gemfile Gemfile.lock scripts/ruby | $(OUTPUT_DIR)
 # without this images can get stale and out of sync from CI system
 $(BUILD_DIR)/node: package.json package-lock.json scripts/node | $(OUTPUT_DIR)
 	./scripts/node pull
-	./scripts/node npm install
+	./scripts/node npm ci
 	@touch $(BUILD_DIR)/node
 
 assets: $(BUILD_DIR)/assets

--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -112,7 +112,7 @@ node {
     stage('Build') {
       checkout scm
       // Install dependencies
-      sh 'npm install'
+      sh 'npm ci'
     }
 }
 
@@ -121,7 +121,7 @@ pipeline {
     agent docker: 'node:6.3'
     stages {
 	stage('Build') {
-	    sh 'npm install'
+	    sh 'npm ci'
 	}
     }
 }

--- a/content/blog/2018/04/2018-04-25-configuring-jenkins-pipeline-with-yaml-file.adoc
+++ b/content/blog/2018/04/2018-04-25-configuring-jenkins-pipeline-with-yaml-file.adoc
@@ -20,7 +20,7 @@ translator: zacker330
 * 支持 Docker 构建。我们的项目依赖的一个或多个 Docker 镜像的执行（应用，数据库，Redis 等）
 * 如有必要，易于配置和复制
 * 易于增加新项目
-* 易于修改构建步骤。工作在项目上的所有人都应该能修改它，如果他们希望执行 `npm install` 或 `yarn install`
+* 易于修改构建步骤。工作在项目上的所有人都应该能修改它，如果他们希望执行 `npm ci` 或 `yarn install`
 
 === 安装Jenkins和Docker
 

--- a/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
+++ b/content/doc/tutorials/build-a-multibranch-pipeline-project.adoc
@@ -158,7 +158,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'npm install'
+                sh 'npm ci'
             }
         }
         stage('Test') {
@@ -255,7 +255,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'npm install'
+                sh 'npm ci'
             }
         }
         stage('Test') {

--- a/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
+++ b/content/doc/tutorials/build-a-node-js-and-react-app-with-npm.adoc
@@ -106,7 +106,7 @@ pipeline {
     stages {
         stage('Build') { // <3>
             steps {
-                sh 'npm install' // <4>
+                sh 'npm ci' // <4>
             }
         }
     }
@@ -201,7 +201,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'npm install'
+                sh 'npm ci'
             }
         }
         stage('Test') { // <2>
@@ -215,7 +215,7 @@ pipeline {
 <1> 这里的 link:/doc/book/pipeline/syntax#environment[`environment`] 指令 设置环境变量 `CI` 为布尔值 `true`, 它对管道中的所有步骤都是有用的。 当 `test.sh` 的`npm test` 命令  (在定义在流水线的下一步的 `Test` 阶段运行) 检测到环境变量 `CI`值为 `true`时, 该命令在
 "non-watch" (i.e. non-interactive) 模式下运行。在"watch" 模式下, `npm test` 期望用户的输入,它能够无限期地停止 CI/CD 应用的运行。
 作为在Jenkins的流水线中指定 `environment` 指令的替代选择, 你也可以在`package.json`域中指定该环境变量的值(通过 `npm test` 命令) 通过以下方式:
-.. 在`jenkins/scripts/test.sh` 取消 `npm install --save-dev cross-env` 命令
+.. 在`jenkins/scripts/test.sh` 取消 `npm ci --save-dev cross-env` 命令
    ( 在`Test` 阶段安装 `cross-env` 依赖)。了解更多请参考 `test.sh` 文件.
 .. 在 `package.json` 文件中修改以下行 (在
    `simple-node-js-react-npm-app` 仓库的根目录下) 从
@@ -286,7 +286,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'npm install'
+                sh 'npm ci'
             }
         }
         stage('Test') {


### PR DESCRIPTION
<!-- Comment:
如果您添加的是翻译类 PR，请查看下面的检查项（模板中的 Comment 只是注释，请在 PR 中删除）：
Please take a look at the checklist below if your PR belongs to a translation:
-->

Ref:

- https://github.com/jenkins-infra/helpdesk/issues/5119

enforcing npm ci over npm install across CI/CD pipelines for reproducible builds.

- `Makefile`: `./scripts/node npm install` → `./scripts/node npm ci` in the dependency target


### 检查项（Submitter checklist）

- [x] 已添加 Issue
- [ ] 已阅读[翻译规范](https://github.com/jenkinsci/localization-zh-cn-plugin/blob/master/specification.md)
- [ ] [原文地址](https://github.com/jenkins-x/jx-docs/blob/master/sample.md please change me)

<!-- Comment:
Fix #0
创建 PR 时，请检查是否添加了对应的 Issue 来跟踪翻译任务。如果已创建，请修改上面 Fix 后面的数字为对应的 Issue 号。
-->

### Desired reviewers

@jenkins-infra/chinese-localization-sig
